### PR TITLE
Update cargo dependency to 0.65

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,9 +159,9 @@ checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
 
 [[package]]
 name = "cargo"
-version = "0.64.0"
+version = "0.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7019448b7d0ffe19d4ab26a340d2efe6da8cf86c8cc01a352b90853e31cd8f7c"
+checksum = "988ba7aa82c0944fd91d119ee24a5c1f865eb2797e0edd90f6c08c7252857ca5"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 binaryen = "0.12"
-cargo = "0.64"
+cargo = "0.65"
 cargo-util = "0.2"
 clap = { version = "3", features = ["derive"] }
 colour = "0.6"

--- a/src/compilation.rs
+++ b/src/compilation.rs
@@ -85,9 +85,10 @@ pub fn build_cfg(config: &Config) -> Result<BuildConfig> {
     let requested_kinds =
         CompileKind::from_requested_targets(config, &[String::from(TARGET_WASM32)])?;
 
-    let jobs = cfg
+    let jobs: u32 = cfg
         .jobs
-        .unwrap_or(thread::available_parallelism()?.get() as u32);
+        .unwrap_or(thread::available_parallelism()?.get() as i32)
+        .try_into()?;
     if jobs == 0 {
         anyhow::bail!("jobs may not be 0");
     }


### PR DESCRIPTION
`workspace-inheritance` has been stabilized in cargo 0.65. This change allows cw-optimizoor to compile contracts using workspace inheritance without needing to specify `cargo-features = ["workspace-inheritance"]` on top of every Cargo.toml