### PR TITLE
chore: Compile only the package's libraries

### DIFF
--- a/src/compilation.rs
+++ b/src/compilation.rs
@@ -56,9 +56,7 @@ pub fn compile_opts(config: &Config, spec: ops::Packages) -> Result<CompileOptio
         build_config: build_cfg(config)?,
         cli_features: CliFeatures::new_all(false),
         spec,
-        filter: CompileFilter::Default {
-            required_features_filterable: false,
-        },
+        filter: CompileFilter::lib_only(),
         target_rustdoc_args: None,
         target_rustc_args: None,
         target_rustc_crate_types: None,


### PR DESCRIPTION
https://github.com/CosmWasm/rust-optimizer/pull/91/files introduces the required `--lib` argument when optimizing with rust-optimizer/workspace-optimizer. This enables the schema generation to live under `src/bin` instead of `examples/`. 

This PR applies the same change to cw-optimizoor